### PR TITLE
feat: Add Main page components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,91 +1,35 @@
-import Image from 'next/image'
-import { Inter } from '@next/font/google'
-import styles from './page.module.css'
+"use client";
 
-const inter = Inter({ subsets: ['latin'] })
+import { useEffect, useState } from "react";
+import Main from "@/components/templates/Main";
+import { axiosGetComments, axiosGetPosts } from "@/networks/axios.custom";
+import { Post, Comment } from "@/types/dto/dataType.dto";
 
 export default function Home() {
+  const [posts, setPosts] = useState<Post[]>();
+  const [comments, setComments] = useState<Comment[]>();
+  // const [page, setPage] = useState<number>(1);
+  // const [viewCount, setViewCount] = useState<number>(10);
+
+  useEffect(() => {
+    axiosGetPosts()
+      .then((response) => {
+        setPosts(response.data);
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  useEffect(() => {
+    axiosGetComments()
+      .then((response) => {
+        setComments(response.data);
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
   return (
-    <main className={styles.main}>
-      <div className={styles.description}>
-        <p>
-          Get started by editing&nbsp;
-          <code className={styles.code}>app/page.tsx</code>
-        </p>
-        <div>
-          <a
-            href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            By{' '}
-            <Image
-              src="/vercel.svg"
-              alt="Vercel Logo"
-              className={styles.vercelLogo}
-              width={100}
-              height={24}
-              priority
-            />
-          </a>
-        </div>
-      </div>
-
-      <div className={styles.center}>
-        <Image
-          className={styles.logo}
-          src="/next.svg"
-          alt="Next.js Logo"
-          width={180}
-          height={37}
-          priority
-        />
-        <div className={styles.thirteen}>
-          <Image src="/thirteen.svg" alt="13" width={40} height={31} priority />
-        </div>
-      </div>
-
-      <div className={styles.grid}>
-        <a
-          href="https://beta.nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={inter.className}>
-            Docs <span>-&gt;</span>
-          </h2>
-          <p className={inter.className}>
-            Find in-depth information about Next.js features and API.
-          </p>
-        </a>
-
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={inter.className}>
-            Templates <span>-&gt;</span>
-          </h2>
-          <p className={inter.className}>Explore the Next.js 13 playground.</p>
-        </a>
-
-        <a
-          href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={inter.className}>
-            Deploy <span>-&gt;</span>
-          </h2>
-          <p className={inter.className}>
-            Instantly deploy your Next.js site to a shareable URL with Vercel.
-          </p>
-        </a>
-      </div>
+    <main>
+      <Main posts={posts} comments={comments} />
     </main>
-  )
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,34 +2,26 @@
 
 import { useEffect, useState } from "react";
 import Main from "@/components/templates/Main";
-import { axiosGetComments, axiosGetPosts } from "@/networks/axios.custom";
+import { axiosGetPosts } from "@/networks/axios.custom";
 import { Post, Comment } from "@/types/dto/dataType.dto";
 
 export default function Home() {
   const [posts, setPosts] = useState<Post[]>();
   const [comments, setComments] = useState<Comment[]>();
-  // const [page, setPage] = useState<number>(1);
-  // const [viewCount, setViewCount] = useState<number>(10);
+  const [page, setPage] = useState<number>(1);
+  const [limit, setLimit] = useState<number>(10);
 
   useEffect(() => {
-    axiosGetPosts()
+    axiosGetPosts(page, limit)
       .then((response) => {
         setPosts(response.data);
       })
       .catch((error) => console.error(error));
-  }, []);
-
-  useEffect(() => {
-    axiosGetComments()
-      .then((response) => {
-        setComments(response.data);
-      })
-      .catch((error) => console.error(error));
-  }, []);
+  }, [page, limit]);
 
   return (
     <main>
-      <Main posts={posts} comments={comments} />
+      <Main posts={posts} />
     </main>
   );
 }

--- a/components/organisms/PostCard.tsx
+++ b/components/organisms/PostCard.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import styled from "@emotion/styled";
+import { Post } from "@/types/dto/dataType.dto";
+
+interface PostCardProps {
+  post: Post;
+  commentsCnt: number | undefined;
+}
+
+export default function PostCard(props: PostCardProps): JSX.Element {
+  const { post, commentsCnt } = props;
+
+  return (
+    <PostCardStyle href={`/detail/${post.id}`}>
+      <SummaryStyle>
+        <p style={{ fontSize: "1.5rem", fontWeight: "700" }}>
+          {post.title ?? "제목이 없습니다."}
+        </p>
+        {/* <p>{post.content}</p> */}
+        <p style={{ color: "#4a5568" }}>content.</p>
+      </SummaryStyle>
+      <BottomStyle>
+        <p>{post.writer}</p>
+        <p style={{ color: "#4a5568" }}>{`${commentsCnt} comments`}</p>
+      </BottomStyle>
+    </PostCardStyle>
+  );
+}
+
+const PostCardStyle = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  cursor: pointer;
+  width: 30rem;
+  height: 20rem;
+  padding: 2rem;
+  border: 1px solid #ffffff;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 0 1px rgb(53 72 91 / 1%), 0 2px 2px rgb(0 0 0 / 1%),
+    0 4px 4px rgb(0 0 0 / 1%), 0 10px 8px rgb(0 0 0 / 1%),
+    0 15px 15px rgb(0 0 0 / 1%), 0 30px 30px rgb(0 0 0 / 1%),
+    0 70px 65px rgb(0 0 0 / 1%);
+  &:hover {
+    background-color: #fafafa;
+    border: 1px solid #fe713b;
+  }
+`;
+
+const SummaryStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+const BottomStyle = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;

--- a/components/organisms/PostCard.tsx
+++ b/components/organisms/PostCard.tsx
@@ -1,14 +1,22 @@
 import Link from "next/link";
 import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import { axiosGetComments } from "@/networks/axios.custom";
 import { Post } from "@/types/dto/dataType.dto";
 
 interface PostCardProps {
   post: Post;
-  commentsCnt: number | undefined;
 }
 
 export default function PostCard(props: PostCardProps): JSX.Element {
-  const { post, commentsCnt } = props;
+  const { post } = props;
+  const [commentsCnt, setCommentsCnt] = useState<number>();
+
+  useEffect(() => {
+    axiosGetComments(post.id).then((response) => {
+      setCommentsCnt(response.data.length);
+    });
+  }, []);
 
   return (
     <PostCardStyle href={`/detail/${post.id}`}>
@@ -16,8 +24,16 @@ export default function PostCard(props: PostCardProps): JSX.Element {
         <p style={{ fontSize: "1.5rem", fontWeight: "700" }}>
           {post.title ?? "제목이 없습니다."}
         </p>
-        {/* <p>{post.content}</p> */}
-        <p style={{ color: "#4a5568" }}>content.</p>
+        <p
+          style={{
+            color: "#4a5568",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            height: "5rem",
+          }}
+        >
+          {post.content}
+        </p>
       </SummaryStyle>
       <BottomStyle>
         <p>{post.writer}</p>

--- a/components/templates/Main.tsx
+++ b/components/templates/Main.tsx
@@ -1,23 +1,18 @@
 import styled from "@emotion/styled";
-import { Post, Comment } from "@/types/dto/dataType.dto";
 import PostCard from "../organisms/PostCard";
+import { Post } from "@/types/dto/dataType.dto";
 
 interface MainProps {
   posts?: Post[];
-  comments?: Comment[];
 }
 
 export default function Main(props: MainProps): JSX.Element {
-  const { posts, comments } = props;
+  const { posts } = props;
 
   return (
     <MainStyle>
-      {posts?.map((post, idx) => {
-        if (idx >= 10) return;
-        const commentsCnt = comments?.filter(
-          (comment) => comment.postId === post.id
-        ).length;
-        return <PostCard key={post.id} post={post} commentsCnt={commentsCnt} />;
+      {posts?.map((post) => {
+        return <PostCard key={post.id} post={post} />;
       })}
     </MainStyle>
   );

--- a/components/templates/Main.tsx
+++ b/components/templates/Main.tsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+import { Post, Comment } from "@/types/dto/dataType.dto";
+import PostCard from "../organisms/PostCard";
+
+interface MainProps {
+  posts?: Post[];
+  comments?: Comment[];
+}
+
+export default function Main(props: MainProps): JSX.Element {
+  const { posts, comments } = props;
+
+  return (
+    <MainStyle>
+      {posts?.map((post, idx) => {
+        if (idx >= 10) return;
+        const commentsCnt = comments?.filter(
+          (comment) => comment.postId === post.id
+        ).length;
+        return <PostCard key={post.id} post={post} commentsCnt={commentsCnt} />;
+      })}
+    </MainStyle>
+  );
+}
+
+const MainStyle = styled.section`
+  background-color: #fdfdfd;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+  overflow-y: scroll;
+  padding: 2rem;
+`;

--- a/networks/axios.custom.ts
+++ b/networks/axios.custom.ts
@@ -1,9 +1,24 @@
 import instance from "./axios.instance";
 
 const axiosGetPostsUrl = "/api/posts/";
-export const axiosGetPosts = async (postId?: number): Promise<any> => {
+export const axiosGetPosts = async (
+  page?: number,
+  limit?: number
+): Promise<any> => {
   try {
-    const response = await instance.get(`${axiosGetPostsUrl}${postId ?? ""}`);
+    const response = await instance.get(
+      `${axiosGetPostsUrl}?_page=${page}&_limit=${limit}`
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const axiosGetTargetPostUrl = "/api/posts/";
+export const axiosGetTargetPost = async (postId: number): Promise<any> => {
+  try {
+    const response = await instance.get(`${axiosGetTargetPostUrl}${postId}`);
     return response;
   } catch (error) {
     throw error;
@@ -11,10 +26,12 @@ export const axiosGetPosts = async (postId?: number): Promise<any> => {
 };
 
 const axiosGetCommentsUrl = "/api/comments/";
-export const axiosGetComments = async (commentId?: number): Promise<any> => {
+export const axiosGetComments = async (postId?: number): Promise<any> => {
   try {
     const response = await instance.get(
-      `${axiosGetCommentsUrl}${commentId ?? ""}`
+      postId
+        ? `${axiosGetCommentsUrl}?postId=${postId}`
+        : `${axiosGetCommentsUrl}`
     );
     return response;
   } catch (error) {

--- a/types/dto/dataType.dto.ts
+++ b/types/dto/dataType.dto.ts
@@ -1,0 +1,22 @@
+export interface Post {
+  // /posts
+  id: number; // 글번호
+  title: string; // 제목
+  content: string; // 내용
+  writer: string; // 작성자
+  password: string; // 비밀번호: 응답 값에서는 보이지 않음
+  created_at: string; // 작성일자: ISO 8601
+  updated_at?: string; // 수정일자: ISO 8601
+}
+
+export interface Comment {
+  // /comments
+  id: number; // 댓글번호
+  postId: number; // 글번호(FK): 댓글이 달린 게시글의 `index`
+  parent?: number; // 부모댓글번호: is답글 ? (부모 댓글의 `index`) : undefined
+  content: string; // 내용
+  writer: string; // 작성자
+  password: string; // 비밀번호: 응답 값에서는 보이지 않음
+  created_at: string; // 작성일자: ISO 8601
+  updated_at?: string; // 수정일자: ISO 8601
+}


### PR DESCRIPTION
# ✨ 추가 기능
- Main Page 추가
  - Main Page
    - posts, comments에 대한 API 요청 
  - Main 컴포넌트
    - PostCard 배치
  - PostCard 컴포넌트
    - Next.js Link 컴포넌트를 사용하여 클릭 시 해당 post 상세보기로 이동
    - post의 제목과 내용, 글쓴이, 댓글 수 표기

# ✏️ TODO
- Main Template
  - Main page에서 전달받은 전체 댓글에 대해 `filter`를 통해 가공하여 댓글 수를 찾는 방법 대신 Query string으로 API를 요청하는 방법으로 개선
- PostCard
  - 내용 일부분만 표기
