### PR TITLE
feat: Add Detail page components

### DIFF
--- a/app/(post)/detail/[slug]/head.tsx
+++ b/app/(post)/detail/[slug]/head.tsx
@@ -1,0 +1,3 @@
+export default function head(): JSX.Element {
+  return <title>detail page</title>;
+}

--- a/app/(post)/detail/[slug]/page.tsx
+++ b/app/(post)/detail/[slug]/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Detail from "@/components/templates/Detail";
+import CommentTemplate from "@/components/templates/CommentTemplate";
+import { axiosGetPosts, axiosGetComments } from "@/networks/axios.custom";
+import { Post, Comment } from "@/types/dto/dataType.dto";
+
+interface PageProps {
+  params: {
+    slug: number;
+  };
+}
+
+export default function page(props: PageProps): JSX.Element {
+  const { params } = props;
+  const [post, setPost] = useState<Post>();
+  const [comments, setComments] = useState<Comment[]>();
+
+  useEffect(() => {
+    axiosGetPosts(params.slug)
+      .then((response) => {
+        setPost(response.data);
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  useEffect(() => {
+    axiosGetComments()
+      .then((response) => {
+        setComments(response.data);
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  return (
+    <main>
+      <Detail post={post} />
+      <CommentTemplate
+        comments={comments?.filter((comment) => comment.postId === post?.id)}
+      />
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,91 +1,35 @@
-import Image from 'next/image'
-import { Inter } from '@next/font/google'
-import styles from './page.module.css'
+"use client";
 
-const inter = Inter({ subsets: ['latin'] })
+import { useEffect, useState } from "react";
+import Main from "@/components/templates/Main";
+import { axiosGetComments, axiosGetPosts } from "@/networks/axios.custom";
+import { Post, Comment } from "@/types/dto/dataType.dto";
 
 export default function Home() {
+  const [posts, setPosts] = useState<Post[]>();
+  const [comments, setComments] = useState<Comment[]>();
+  // const [page, setPage] = useState<number>(1);
+  // const [viewCount, setViewCount] = useState<number>(10);
+
+  useEffect(() => {
+    axiosGetPosts()
+      .then((response) => {
+        setPosts(response.data);
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  useEffect(() => {
+    axiosGetComments()
+      .then((response) => {
+        setComments(response.data);
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
   return (
-    <main className={styles.main}>
-      <div className={styles.description}>
-        <p>
-          Get started by editing&nbsp;
-          <code className={styles.code}>app/page.tsx</code>
-        </p>
-        <div>
-          <a
-            href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            By{' '}
-            <Image
-              src="/vercel.svg"
-              alt="Vercel Logo"
-              className={styles.vercelLogo}
-              width={100}
-              height={24}
-              priority
-            />
-          </a>
-        </div>
-      </div>
-
-      <div className={styles.center}>
-        <Image
-          className={styles.logo}
-          src="/next.svg"
-          alt="Next.js Logo"
-          width={180}
-          height={37}
-          priority
-        />
-        <div className={styles.thirteen}>
-          <Image src="/thirteen.svg" alt="13" width={40} height={31} priority />
-        </div>
-      </div>
-
-      <div className={styles.grid}>
-        <a
-          href="https://beta.nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={inter.className}>
-            Docs <span>-&gt;</span>
-          </h2>
-          <p className={inter.className}>
-            Find in-depth information about Next.js features and API.
-          </p>
-        </a>
-
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={inter.className}>
-            Templates <span>-&gt;</span>
-          </h2>
-          <p className={inter.className}>Explore the Next.js 13 playground.</p>
-        </a>
-
-        <a
-          href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className={styles.card}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className={inter.className}>
-            Deploy <span>-&gt;</span>
-          </h2>
-          <p className={inter.className}>
-            Instantly deploy your Next.js site to a shareable URL with Vercel.
-          </p>
-        </a>
-      </div>
+    <main>
+      <Main posts={posts} comments={comments} />
     </main>
-  )
+  );
 }

--- a/components/organisms/CommentCard.tsx
+++ b/components/organisms/CommentCard.tsx
@@ -1,0 +1,42 @@
+import styled from "@emotion/styled";
+import { Comment } from "@/types/dto/dataType.dto";
+
+interface CommentCardProps {
+  comment: Comment;
+}
+
+export default function CommentCard(props: CommentCardProps): JSX.Element {
+  const { comment } = props;
+
+  return (
+    <CommentCardStyle>
+      <HeadStyle>
+        <span>{comment?.writer ?? "anonymous"}</span>
+        <HeadButtonStyle>
+          <button>수정</button>
+          <button>삭제</button>
+        </HeadButtonStyle>
+      </HeadStyle>
+      <ContentStyle>{comment.content}</ContentStyle>
+    </CommentCardStyle>
+  );
+}
+
+const CommentCardStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 20rem;
+`;
+
+const HeadStyle = styled.div`
+  padding: 1rem 0;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const HeadButtonStyle = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+const ContentStyle = styled.div``;

--- a/components/organisms/CommentForm.tsx
+++ b/components/organisms/CommentForm.tsx
@@ -1,0 +1,63 @@
+import styled from "@emotion/styled";
+import { useState } from "react";
+import { axiosPostComment } from "@/networks/axios.custom";
+import { Comment } from "@/types/dto/dataType.dto";
+
+/**
+ * TODO
+ * - 댓글번호를 순차적으로 POST 하는 방법
+ * @returns
+ */
+export default function CommentForm(): JSX.Element {
+  const [newComment, setNewComment] = useState<Object>({});
+
+  const handleChange = (e: any): void => {
+    const value = e.target.value;
+    setNewComment((prev) => ({
+      ...prev,
+      // id:
+      postId: 1,
+      parrent: null,
+      content: value,
+      writer: null,
+      password: "string",
+      // created_at: string; // 작성일자: ISO 8601
+      updated_at: "string",
+    }));
+  };
+
+  const handleClick = (): void => {
+    if (newComment)
+      axiosPostComment(newComment)
+        .then((response) => console.log(response))
+        .catch((error) => console.error(error));
+  };
+
+  return (
+    <CommentFormStyle>
+      <InputStyle>
+        <input placeholder="댓글을 작성하세요" onChange={handleChange} />
+      </InputStyle>
+      <ButtonStyle>
+        <button onClick={handleClick}>작성하기</button>
+      </ButtonStyle>
+    </CommentFormStyle>
+  );
+}
+
+const CommentFormStyle = styled.div`
+  width: 20rem;
+  display: flex;
+  flex-direction: column;
+`;
+
+const InputStyle = styled.div`
+  border: 1px solid lightgray;
+  border-radius: 0.25rem;
+`;
+
+const ButtonStyle = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+`;

--- a/components/organisms/PostCard.tsx
+++ b/components/organisms/PostCard.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import styled from "@emotion/styled";
+import { Post } from "@/types/dto/dataType.dto";
+
+interface PostCardProps {
+  post: Post;
+  commentsCnt: number | undefined;
+}
+
+export default function PostCard(props: PostCardProps): JSX.Element {
+  const { post, commentsCnt } = props;
+
+  return (
+    <PostCardStyle href={`/detail/${post.id}`}>
+      <SummaryStyle>
+        <p style={{ fontSize: "1.5rem", fontWeight: "700" }}>
+          {post.title ?? "제목이 없습니다."}
+        </p>
+        {/* <p>{post.content}</p> */}
+        <p style={{ color: "#4a5568" }}>content.</p>
+      </SummaryStyle>
+      <BottomStyle>
+        <p>{post.writer}</p>
+        <p style={{ color: "#4a5568" }}>{`${commentsCnt} comments`}</p>
+      </BottomStyle>
+    </PostCardStyle>
+  );
+}
+
+const PostCardStyle = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  cursor: pointer;
+  width: 30rem;
+  height: 20rem;
+  padding: 2rem;
+  border: 1px solid #ffffff;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 0 1px rgb(53 72 91 / 1%), 0 2px 2px rgb(0 0 0 / 1%),
+    0 4px 4px rgb(0 0 0 / 1%), 0 10px 8px rgb(0 0 0 / 1%),
+    0 15px 15px rgb(0 0 0 / 1%), 0 30px 30px rgb(0 0 0 / 1%),
+    0 70px 65px rgb(0 0 0 / 1%);
+  &:hover {
+    background-color: #fafafa;
+    border: 1px solid #fe713b;
+  }
+`;
+
+const SummaryStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+const BottomStyle = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;

--- a/components/templates/CommentTemplate.tsx
+++ b/components/templates/CommentTemplate.tsx
@@ -1,0 +1,33 @@
+import styled from "@emotion/styled";
+import CommentForm from "../organisms/CommentForm";
+import CommentCard from "../organisms/CommentCard";
+import { Comment } from "@/types/dto/dataType.dto";
+
+interface CommentTemplateProps {
+  comments?: Comment[];
+}
+
+export default function CommentTemplate(
+  props: CommentTemplateProps
+): JSX.Element {
+  const { comments } = props;
+
+  return (
+    <CommentTemplateStyle>
+      <CommentForm />
+      {comments?.map((comment) => {
+        return <CommentCard key={comment.id} comment={comment} />;
+      })}
+    </CommentTemplateStyle>
+  );
+}
+
+const CommentTemplateStyle = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.5rem;
+  overflow-y: scroll;
+  padding: 2rem;
+`;

--- a/components/templates/Detail.tsx
+++ b/components/templates/Detail.tsx
@@ -1,0 +1,53 @@
+import styled from "@emotion/styled";
+import { Post } from "@/types/dto/dataType.dto";
+
+interface DetailProps {
+  post: Post | undefined;
+}
+
+export default function Detail(props: DetailProps): JSX.Element {
+  const { post } = props;
+
+  return (
+    <DetailStyle>
+      <HeadStyle>
+        <h1>{post?.title}</h1>
+        <HeadBarStyle>
+          <span>{`${post?.writer} ${post?.created_at}`}</span>
+          <HeadButtonStyle>
+            <button>수정</button>
+            <button>삭제</button>
+          </HeadButtonStyle>
+        </HeadBarStyle>
+      </HeadStyle>
+      <ContentStyle>{post?.content}</ContentStyle>
+    </DetailStyle>
+  );
+}
+
+const DetailStyle = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #fdfdfd;
+`;
+
+const HeadStyle = styled.div`
+  width: 20rem;
+  margin-top: 5rem;
+`;
+
+const HeadBarStyle = styled.div`
+  padding: 1rem 0;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const HeadButtonStyle = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+const ContentStyle = styled.article`
+  width: 20rem;
+`;

--- a/components/templates/Main.tsx
+++ b/components/templates/Main.tsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+import { Post, Comment } from "@/types/dto/dataType.dto";
+import PostCard from "../organisms/PostCard";
+
+interface MainProps {
+  posts?: Post[];
+  comments?: Comment[];
+}
+
+export default function Main(props: MainProps): JSX.Element {
+  const { posts, comments } = props;
+
+  return (
+    <MainStyle>
+      {posts?.map((post, idx) => {
+        if (idx >= 10) return;
+        const commentsCnt = comments?.filter(
+          (comment) => comment.postId === post.id
+        ).length;
+        return <PostCard key={post.id} post={post} commentsCnt={commentsCnt} />;
+      })}
+    </MainStyle>
+  );
+}
+
+const MainStyle = styled.section`
+  background-color: #fdfdfd;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+  overflow-y: scroll;
+  padding: 2rem;
+`;

--- a/types/dto/dataType.dto.ts
+++ b/types/dto/dataType.dto.ts
@@ -1,0 +1,22 @@
+export interface Post {
+  // /posts
+  id: number; // 글번호
+  title: string; // 제목
+  content: string; // 내용
+  writer: string; // 작성자
+  password: string; // 비밀번호: 응답 값에서는 보이지 않음
+  created_at: string; // 작성일자: ISO 8601
+  updated_at?: string; // 수정일자: ISO 8601
+}
+
+export interface Comment {
+  // /comments
+  id: number; // 댓글번호
+  postId: number; // 글번호(FK): 댓글이 달린 게시글의 `index`
+  parent?: number; // 부모댓글번호: is답글 ? (부모 댓글의 `index`) : undefined
+  content: string; // 내용
+  writer: string; // 작성자
+  password: string; // 비밀번호: 응답 값에서는 보이지 않음
+  created_at: string; // 작성일자: ISO 8601
+  updated_at?: string; // 수정일자: ISO 8601
+}


### PR DESCRIPTION
# ✨ 추가 기능
- Detail Page 추가
  - Detail Page
    - Main page에서 post 클릭 시 넘겨받는 slug 값을 통해 `postId`에 따른 페이지로 이동
    - 해당 post, comments에 대한 API 요청
  - Detail 컴포넌트
    - 해당 post의 제목, 글쓴이, 내용, 작성일자 표시
  - CommentTemplate 컴포넌트
    - CommentForm 컴포넌트와 해당 post에 연결된 모든 CommentCard 컴포넌트 배치
  - CommentForm
    - Comment 작성 및 POST 요청 역할 담당
  - CommentCard
    - 해당 comment의 글쓴이, 내용 표시

# ✏️ TODO
- 전체적인 UI 수정
- CommentForm
  - POST 기능 완성
