### PR TITLE
feat: Add Comment post

### DIFF
--- a/app/(post)/detail/[slug]/page.tsx
+++ b/app/(post)/detail/[slug]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Detail from "@/components/templates/Detail";
 import CommentTemplate from "@/components/templates/CommentTemplate";
-import { axiosGetPosts, axiosGetComments } from "@/networks/axios.custom";
+import { axiosGetTargetPost, axiosGetComments } from "@/networks/axios.custom";
 import { Post, Comment } from "@/types/dto/dataType.dto";
 
 interface PageProps {
@@ -18,7 +18,7 @@ export default function page(props: PageProps): JSX.Element {
   const [comments, setComments] = useState<Comment[]>();
 
   useEffect(() => {
-    axiosGetPosts(params.slug)
+    axiosGetTargetPost(params.slug)
       .then((response) => {
         setPost(response.data);
       })
@@ -26,7 +26,7 @@ export default function page(props: PageProps): JSX.Element {
   }, []);
 
   useEffect(() => {
-    axiosGetComments()
+    axiosGetComments(params.slug)
       .then((response) => {
         setComments(response.data);
       })
@@ -36,9 +36,7 @@ export default function page(props: PageProps): JSX.Element {
   return (
     <main>
       <Detail post={post} />
-      <CommentTemplate
-        comments={comments?.filter((comment) => comment.postId === post?.id)}
-      />
+      <CommentTemplate postId={post?.id} comments={comments} />
     </main>
   );
 }

--- a/components/organisms/CommentCard.tsx
+++ b/components/organisms/CommentCard.tsx
@@ -11,10 +11,10 @@ export default function CommentCard(props: CommentCardProps): JSX.Element {
   return (
     <CommentCardStyle>
       <HeadStyle>
-        <span>{comment?.writer ?? "anonymous"}</span>
+        <span>{comment.writer}</span>
         <HeadButtonStyle>
-          <button>수정</button>
-          <button>삭제</button>
+          {/* <button>수정</button>
+          <button>삭제</button> */}
         </HeadButtonStyle>
       </HeadStyle>
       <ContentStyle>{comment.content}</ContentStyle>

--- a/components/organisms/CommentForm.tsx
+++ b/components/organisms/CommentForm.tsx
@@ -1,14 +1,20 @@
 import styled from "@emotion/styled";
 import { useState } from "react";
+import InputInstance from "../atoms/inputs/InputInstance";
 import { axiosPostComment } from "@/networks/axios.custom";
 import { Comment } from "@/types/dto/dataType.dto";
+
+interface CommentFormProps {
+  postId: number | undefined;
+}
 
 /**
  * TODO
  * - 댓글번호를 순차적으로 POST 하는 방법
  * @returns
  */
-export default function CommentForm(): JSX.Element {
+export default function CommentForm(props: CommentFormProps): JSX.Element {
+  const { postId } = props;
   const [newComment, setNewComment] = useState<Object>({});
 
   const handleChange = (e: any): void => {
@@ -16,7 +22,7 @@ export default function CommentForm(): JSX.Element {
     setNewComment((prev) => ({
       ...prev,
       // id:
-      postId: 1,
+      postId: postId,
       parrent: null,
       content: value,
       writer: null,
@@ -35,9 +41,7 @@ export default function CommentForm(): JSX.Element {
 
   return (
     <CommentFormStyle>
-      <InputStyle>
-        <input placeholder="댓글을 작성하세요" onChange={handleChange} />
-      </InputStyle>
+      <TextAreaStyle placeholder="댓글을 입력하세요" onChange={handleChange} />
       <ButtonStyle>
         <button onClick={handleClick}>작성하기</button>
       </ButtonStyle>
@@ -47,16 +51,24 @@ export default function CommentForm(): JSX.Element {
 
 const CommentFormStyle = styled.div`
   width: 20rem;
+  height: 5rem;
   display: flex;
   flex-direction: column;
+  margin-bottom: 1rem;
 `;
 
-const InputStyle = styled.div`
+const TextAreaStyle = styled.textarea`
+  padding: 1rem;
+  outline: none;
+  resize: none;
   border: 1px solid lightgray;
   border-radius: 0.25rem;
+  min-height: 4rem;
+  font-size: 1rem;
 `;
 
 const ButtonStyle = styled.div`
+  height: 1rem;
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;

--- a/components/organisms/PostCard.tsx
+++ b/components/organisms/PostCard.tsx
@@ -21,9 +21,7 @@ export default function PostCard(props: PostCardProps): JSX.Element {
   return (
     <PostCardStyle href={`/detail/${post.id}`}>
       <SummaryStyle>
-        <p style={{ fontSize: "1.5rem", fontWeight: "700" }}>
-          {post.title ?? "제목이 없습니다."}
-        </p>
+        <p style={{ fontSize: "1.5rem", fontWeight: "700" }}>{post.title}</p>
         <p
           style={{
             color: "#4a5568",

--- a/components/templates/CommentTemplate.tsx
+++ b/components/templates/CommentTemplate.tsx
@@ -4,17 +4,18 @@ import CommentCard from "../organisms/CommentCard";
 import { Comment } from "@/types/dto/dataType.dto";
 
 interface CommentTemplateProps {
+  postId: number | undefined;
   comments?: Comment[];
 }
 
 export default function CommentTemplate(
   props: CommentTemplateProps
 ): JSX.Element {
-  const { comments } = props;
+  const { postId, comments } = props;
 
   return (
     <CommentTemplateStyle>
-      <CommentForm />
+      <CommentForm postId={postId} />
       {comments?.map((comment) => {
         return <CommentCard key={comment.id} comment={comment} />;
       })}

--- a/components/templates/Detail.tsx
+++ b/components/templates/Detail.tsx
@@ -15,8 +15,8 @@ export default function Detail(props: DetailProps): JSX.Element {
         <HeadBarStyle>
           <span>{`${post?.writer} ${post?.created_at}`}</span>
           <HeadButtonStyle>
-            <button>수정</button>
-            <button>삭제</button>
+            {/* <button>수정</button>
+            <button>삭제</button> */}
           </HeadButtonStyle>
         </HeadBarStyle>
       </HeadStyle>
@@ -29,7 +29,6 @@ const DetailStyle = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-color: #fdfdfd;
 `;
 
 const HeadStyle = styled.div`


### PR DESCRIPTION
# ✨ 추가 기능
- 해당 post에서 Comment를 작성하는 기능 추가

# ♻️ 변경 사항
### 기존
- Detail page에서 모든 comments를 호출하고, `filter`를 사용하여 `postId`에 해당되는 요소만 CommentTemplate 컴포넌트에 props으로 전달
### 변경
- `postId`에 해당하는 comments만 호출 후 전달

# ✏️ TODO
- UI Button 컴포넌트 추가
