### PR TITLE
feat: Responsive Web with media query && Apply post, comment policy

### DIFF
--- a/app/(post)/detail/[slug]/head.tsx
+++ b/app/(post)/detail/[slug]/head.tsx
@@ -1,3 +1,10 @@
-export default function head(): JSX.Element {
-  return <title>detail page</title>;
+export default function Head() {
+  return (
+    <>
+      <title>detail</title>
+      <meta content="width=device-width, initial-scale=1" name="viewport" />
+      <meta name="description" content="More details on the post" />
+      <link rel="icon" href="/favicon.ico" />
+    </>
+  );
 }

--- a/app/(post)/write/head.tsx
+++ b/app/(post)/write/head.tsx
@@ -1,3 +1,10 @@
-export default function head(): JSX.Element {
-  return <title> write page </title>;
+export default function Head() {
+  return (
+    <>
+      <title>write</title>
+      <meta content="width=device-width, initial-scale=1" name="viewport" />
+      <meta name="description" content="Create a post" />
+      <link rel="icon" href="/favicon.ico" />
+    </>
+  );
 }

--- a/app/(post)/write/page.tsx
+++ b/app/(post)/write/page.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-import styled from "@emotion/styled";
-import WriteForm from "@/components/organisms/WriteForm";
+import Write from "@/components/templates/Write";
 
 export default function page(): JSX.Element {
   return (
-    <MainStyle>
-      <WriteForm />
-    </MainStyle>
+    <main>
+      <Write />
+    </main>
   );
 }
-
-const MainStyle = styled.main`
-  display: flex;
-  justify-content: center;
-`;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useState } from "react";
 import Filter from "@/components/templates/Filter";
 import Main from "@/components/templates/Main";
+import Pagination from "@/components/templates/Pagination";
 import { axiosGetPosts } from "@/networks/axios.custom";
 import { Post } from "@/types/dto/dataType.dto";
-import Pagination from "@/components/organisms/Pagination";
 
 export default function Home() {
   const [posts, setPosts] = useState<Post[]>([]);

--- a/components/atoms/buttons/BaseButton.tsx
+++ b/components/atoms/buttons/BaseButton.tsx
@@ -1,25 +1,45 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 interface BaseButtonProps {
-  value: string;
+  theme: string;
   handleClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  value: string;
 }
 
 export default function BaseButton(props: BaseButtonProps): JSX.Element {
   return (
-    <BaseButtonStyle onClick={props.handleClick}>{props.value}</BaseButtonStyle>
+    <BaseButtonStyle theme={props.theme} onClick={props.handleClick}>
+      {props.value}
+    </BaseButtonStyle>
   );
 }
 
 const BaseButtonStyle = styled.button`
   border: 0;
-  border-radius: 0.25rem;
-  width: 6rem;
-  height: 2rem;
-  background-color: #fe713b;
-  color: #ffffff;
   cursor: pointer;
-  &:hover {
-    background-color: #fc8d61;
-  }
+
+  ${(props) =>
+    props.theme === "contained" &&
+    css`
+      width: 8rem;
+      height: 2rem;
+      color: #ffffff;
+      background-color: #fe713b;
+      border-radius: 0.25rem;
+      &:hover {
+        background-color: #fc8d61;
+      }
+    `}
+  ${(props) =>
+    props.theme === "text" &&
+    css`
+      width: 3rem;
+      height: 2rem;
+      color: #4a5568;
+      background-color: transparent;
+      &:hover {
+        border-bottom: 1px solid #4a5568;
+      }
+    `}
 `;

--- a/components/atoms/inputs/InputInstance.tsx
+++ b/components/atoms/inputs/InputInstance.tsx
@@ -4,6 +4,7 @@ import { SetStateAction, Dispatch } from "react";
 interface inputInstanceProps {
   value: string;
   setValue: Dispatch<SetStateAction<string>>;
+  maxLength?: number;
   placeholder: string;
 }
 
@@ -15,8 +16,9 @@ export default function InputInstance(props: inputInstanceProps): JSX.Element {
   return (
     <InputInstanceStyle
       value={props.value}
-      onChange={handleChange}
+      maxLength={props.maxLength}
       placeholder={props.placeholder}
+      onChange={handleChange}
     />
   );
 }

--- a/components/atoms/inputs/TextAreaInstance.tsx
+++ b/components/atoms/inputs/TextAreaInstance.tsx
@@ -1,8 +1,11 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import { SetStateAction, Dispatch } from "react";
 
 interface TextAreaInstanceProps {
+  theme: string;
   value: string;
+  maxLength?: number;
   setValue: Dispatch<SetStateAction<string>>;
   placeholder: string;
 }
@@ -16,7 +19,9 @@ export default function TextAreaInstance(
 
   return (
     <TextAreaStyle
+      theme={props.theme}
       value={props.value}
+      maxLength={props.maxLength}
       placeholder={props.placeholder}
       onChange={handleChange}
     />
@@ -29,6 +34,19 @@ const TextAreaStyle = styled.textarea`
   resize: none;
   border: 1px solid lightgray;
   border-radius: 0.25rem;
-  min-height: 5rem;
   font-size: 1rem;
+  ${(props) =>
+    props.theme === "post" &&
+    css`
+      min-height: 30rem;
+
+      @media screen and (max-width: 768px) {
+        min-height: 20rem;
+      }
+    `}
+  ${(props) =>
+    props.theme === "comment" &&
+    css`
+      min-height: 5rem;
+    `}
 `;

--- a/components/organisms/CommentForm.tsx
+++ b/components/organisms/CommentForm.tsx
@@ -3,16 +3,18 @@ import { useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 import InputInstance from "../atoms/inputs/InputInstance";
 import BaseButton from "../atoms/buttons/BaseButton";
-import { axiosPostComment } from "@/networks/axios.custom";
 import TextAreaInstance from "../atoms/inputs/TextAreaInstance";
+import { axiosPostComment } from "@/networks/axios.custom";
+import { commentPolicy } from "@/types/enum/policy";
 
 interface CommentFormProps {
   postId: number;
+  commentsLength: number;
   parrent?: number;
 }
 
 export default function CommentForm(props: CommentFormProps): JSX.Element {
-  const { postId, parrent } = props;
+  const { postId, commentsLength, parrent } = props;
   const [writer, setWriter] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [content, setContent] = useState<string>("");
@@ -31,49 +33,59 @@ export default function CommentForm(props: CommentFormProps): JSX.Element {
   }, [writer, password, content]);
 
   const handleClick = (): void => {
-    axiosPostComment(newComment)
-      .then((response) => {
-        mutate(`/api/comments/?postId=${postId}`);
-        console.log(response.data);
-      })
-      .catch((error) => console.error(error));
+    if (content !== "")
+      axiosPostComment(newComment)
+        .then((response) => {
+          mutate(`/api/comments/?postId=${postId}`);
+        })
+        .catch((error) => console.error(error));
   };
 
   return (
     <CommentFormStyle>
+      <p style={{ fontWeight: "700" }}>{`${commentsLength}개의 댓글`}</p>
       <InputInstance
         value={writer}
         setValue={setWriter}
+        maxLength={commentPolicy.writer}
         placeholder={"글쓴이를 입력하세요."}
       />
       <InputInstance
         value={password}
         setValue={setPassword}
+        maxLength={commentPolicy.password}
         placeholder={"비밀번호를 입력하세요."}
       />
       <TextAreaInstance
+        theme={"comment"}
         value={content}
+        maxLength={commentPolicy.content}
         setValue={setContent}
         placeholder={"내용을 입력하세요"}
       />
       <ButtonStyle>
-        <BaseButton value={"작성하기"} handleClick={handleClick} />
+        <BaseButton
+          theme={"contained"}
+          value={"작성하기"}
+          handleClick={handleClick}
+        />
       </ButtonStyle>
     </CommentFormStyle>
   );
 }
 
 const CommentFormStyle = styled.div`
-  width: 20rem;
-  height: 20rem;
+  width: 48rem;
+  gap: 0.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin-bottom: 1rem;
+
+  @media screen and (max-width: 768px) {
+    width: 20rem;
+  }
 `;
 
 const ButtonStyle = styled.div`
-  height: 1rem;
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;

--- a/components/organisms/PostCard.tsx
+++ b/components/organisms/PostCard.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import styled from "@emotion/styled";
-import { useEffect, useState } from "react";
-import { axiosGetComments } from "@/networks/axios.custom";
+import { useComments } from "@/hooks/useComments";
 import { Post } from "@/types/dto/dataType.dto";
 
 interface PostCardProps {
@@ -10,13 +9,7 @@ interface PostCardProps {
 
 export default function PostCard(props: PostCardProps): JSX.Element {
   const { post } = props;
-  const [commentsCnt, setCommentsCnt] = useState<number>();
-
-  useEffect(() => {
-    axiosGetComments(post.id).then((response) => {
-      setCommentsCnt(response.data.length);
-    });
-  }, []);
+  const { comments, isLoading, isError } = useComments(post.id);
 
   return (
     <PostCardStyle href={`/detail/${post.id}`}>
@@ -25,9 +18,6 @@ export default function PostCard(props: PostCardProps): JSX.Element {
         <p
           style={{
             color: "#4a5568",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            height: "5rem",
           }}
         >
           {post.content}
@@ -35,20 +25,20 @@ export default function PostCard(props: PostCardProps): JSX.Element {
       </SummaryStyle>
       <BottomStyle>
         <p>{post.writer}</p>
-        <p style={{ color: "#4a5568" }}>{`${commentsCnt} comments`}</p>
+        <p style={{ color: "#4a5568" }}>{`${comments?.length} comments`}</p>
       </BottomStyle>
     </PostCardStyle>
   );
 }
 
 const PostCardStyle = styled(Link)`
+  width: 20rem;
+  height: 20rem;
+  padding: 1rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   cursor: pointer;
-  width: 30rem;
-  height: 20rem;
-  padding: 2rem;
   border: 1px solid #ffffff;
   border-radius: 0.5rem;
   box-shadow: 0 0 0 1px rgb(53 72 91 / 1%), 0 2px 2px rgb(0 0 0 / 1%),
@@ -62,10 +52,16 @@ const PostCardStyle = styled(Link)`
 `;
 
 const SummaryStyle = styled.div`
+  gap: 0.5rem;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  gap: 1rem;
+  p {
+    padding: 0.5rem;
+    height: 2rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 const BottomStyle = styled.div`

--- a/components/organisms/ViewLimitBox.tsx
+++ b/components/organisms/ViewLimitBox.tsx
@@ -30,12 +30,11 @@ const ViewLimitBoxStyle = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
 `;
 
 const SelectStyle = styled.select`
   width: 3rem;
-  height: 2rem;
+  height: 1.5rem;
   border-radius: 0.25rem;
   outline: 0;
 `;

--- a/components/organisms/WriteForm.tsx
+++ b/components/organisms/WriteForm.tsx
@@ -7,6 +7,7 @@ import InputInstance from "../atoms/inputs/InputInstance";
 import BaseButton from "../atoms/buttons/BaseButton";
 import TextAreaInstance from "../atoms/inputs/TextAreaInstance";
 import { axiosPostPost } from "@/networks/axios.custom";
+import { postPolicy } from "@/types/enum/policy";
 
 export default function WriteForm(): JSX.Element {
   const [title, setTitle] = useState<string>("");
@@ -19,24 +20,22 @@ export default function WriteForm(): JSX.Element {
   useEffect(() => {
     setNewPost((prev) => ({
       ...prev,
-      // id: number,
       title: title,
       content: content,
       writer: writer,
       password: password,
-      // created_at: string,
-      updated_at: "string",
     }));
   }, [title, writer, password, content]);
 
   const handleClick = (): void => {
-    axiosPostPost(newPost)
-      .then((response) => {
-        if (response.status === 201) {
-          router.push(`/detail/${response.data.id}`);
-        }
-      })
-      .catch((error) => console.error(error));
+    if (content !== "")
+      axiosPostPost(newPost)
+        .then((response) => {
+          if (response.status === 201) {
+            router.push(`/detail/${response.data.id}`);
+          }
+        })
+        .catch((error) => console.error(error));
   };
 
   return (
@@ -44,41 +43,51 @@ export default function WriteForm(): JSX.Element {
       <InputInstance
         value={title}
         setValue={setTitle}
+        maxLength={postPolicy.title}
         placeholder={"제목을 입력하세요."}
       />
       <InputInstance
         value={writer}
+        maxLength={postPolicy.writer}
         setValue={setWriter}
         placeholder={"글쓴이를 입력하세요."}
       />
       <InputInstance
         value={password}
         setValue={setPassword}
+        maxLength={postPolicy.password}
         placeholder={"비밀번호를 입력하세요."}
       />
       <TextAreaInstance
+        theme={"post"}
         value={content}
+        maxLength={postPolicy.content}
         setValue={setContent}
         placeholder={"내용을 입력하세요"}
       />
       <ButtonStyle>
-        <BaseButton value={"작성하기"} handleClick={handleClick} />
+        <BaseButton
+          theme={"contained"}
+          value={"작성하기"}
+          handleClick={handleClick}
+        />
       </ButtonStyle>
     </WrtieFormStyle>
   );
 }
 
 const WrtieFormStyle = styled.div`
-  width: 20rem;
-  height: 20rem;
+  width: 48rem;
+  gap: 0.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin: 5rem 0;
+
+  @media screen and (max-width: 768px) {
+    width: 20rem;
+  }
 `;
 
 const ButtonStyle = styled.div`
-  height: 1rem;
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;

--- a/components/templates/CommentTemplate.tsx
+++ b/components/templates/CommentTemplate.tsx
@@ -16,7 +16,7 @@ export default function CommentTemplate(
 
   return (
     <CommentTemplateStyle>
-      <CommentForm postId={postId} />
+      <CommentForm postId={postId} commentsLength={comments?.length} />
       {!isLoading &&
         comments.map((comment: Comment) => {
           return (
@@ -28,11 +28,9 @@ export default function CommentTemplate(
 }
 
 const CommentTemplateStyle = styled.section`
+  gap: 3rem;
+  margin-bottom: 2rem;
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
   align-items: center;
-  gap: 1.5rem;
-  overflow-y: scroll;
-  padding: 2rem;
 `;

--- a/components/templates/Detail.tsx
+++ b/components/templates/Detail.tsx
@@ -1,52 +1,22 @@
 import styled from "@emotion/styled";
 import { Post } from "@/types/dto/dataType.dto";
+import DetailCard from "../organisms/DetailCard";
 
 interface DetailProps {
-  post: Post | undefined;
+  post: Post;
 }
 
 export default function Detail(props: DetailProps): JSX.Element {
-  const { post } = props;
-
   return (
     <DetailStyle>
-      <HeadStyle>
-        <h1>{post?.title}</h1>
-        <HeadBarStyle>
-          <span>{`${post?.writer} ${post?.created_at}`}</span>
-          <HeadButtonStyle>
-            {/* <button>수정</button>
-            <button>삭제</button> */}
-          </HeadButtonStyle>
-        </HeadBarStyle>
-      </HeadStyle>
-      <ContentStyle>{post?.content}</ContentStyle>
+      <DetailCard post={props.post} />
     </DetailStyle>
   );
 }
 
 const DetailStyle = styled.section`
+  margin: 2rem 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-`;
-
-const HeadStyle = styled.div`
-  width: 20rem;
-  margin-top: 5rem;
-`;
-
-const HeadBarStyle = styled.div`
-  padding: 1rem 0;
-  display: flex;
-  justify-content: space-between;
-`;
-
-const HeadButtonStyle = styled.div`
-  display: flex;
-  gap: 0.5rem;
-`;
-
-const ContentStyle = styled.article`
-  width: 20rem;
 `;

--- a/components/templates/Filter.tsx
+++ b/components/templates/Filter.tsx
@@ -20,7 +20,9 @@ export default function Filter(props: FilterProps): JSX.Element {
 
 const FilterStyle = styled.section`
   height: 5vh;
+  padding: 1rem 2rem;
   display: flex;
   justify-content: space-between;
-  padding: 1rem 5rem;
+  flex-direction: row-reverse;
+  align-items: center;
 `;

--- a/components/templates/Header.tsx
+++ b/components/templates/Header.tsx
@@ -11,15 +11,15 @@ export default function Header(): JSX.Element {
         <p style={{ fontSize: "1.5rem", fontWeight: "700" }}>SD Board</p>
       </Link>
       <Link href={"/write"}>
-        <BaseButton value={"Create a post"} />
+        <BaseButton theme={"contained"} value={"Create a post"} />
       </Link>
     </HeaderStyle>
   );
 }
 
-const HeaderStyle = styled.div`
-  height: 10vh;
-  padding: 0 3rem;
+const HeaderStyle = styled.header`
+  height: 5vh;
+  padding: 1rem 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/components/templates/Main.tsx
+++ b/components/templates/Main.tsx
@@ -19,10 +19,10 @@ export default function Main(props: MainProps): JSX.Element {
 }
 
 const MainStyle = styled.section`
+  gap: 1rem;
   display: flex;
-  flex-wrap: wrap;
   justify-content: center;
-  gap: 1.5rem;
+  align-items: center;
+  flex-wrap: wrap;
   overflow-y: scroll;
-  padding: 2rem;
 `;

--- a/components/templates/Pagination.tsx
+++ b/components/templates/Pagination.tsx
@@ -20,47 +20,47 @@ export default function Pagination(props: PaginationProps): JSX.Element {
 
   return (
     <PaginationStyle>
-      <>
-        <ButtonStyle onClick={() => setPage(page - 1)} disabled={page === 1}>
-          &lt;
-        </ButtonStyle>
+      <ButtonStyle onClick={() => setPage(page - 1)} disabled={page === 1}>
+        &lt;
+      </ButtonStyle>
 
-        {Array(maxPage < 5 ? maxPage : 5)
-          .fill(0)
-          .map((_, i) => {
-            return (
-              <ButtonStyle
-                key={(i % 5) + 1 + 5 * offset}
-                style={{
-                  color: page === (i % 5) + 1 + 5 * offset ? "red" : "inherit",
-                }}
-                onClick={handleClick}
-              >
-                {(i % 5) + 1 + 5 * offset}
-              </ButtonStyle>
-            );
-          })}
-        <ButtonStyle
-          onClick={() => setPage(page + 1)}
-          disabled={page === maxPage}
-        >
-          &gt;
-        </ButtonStyle>
-      </>
+      {Array(maxPage < 5 ? maxPage : 5)
+        .fill(0)
+        .map((_, i) => {
+          return (
+            <ButtonStyle
+              key={(i % 5) + 1 + 5 * offset}
+              style={{
+                color: page === (i % 5) + 1 + 5 * offset ? "red" : "inherit",
+              }}
+              onClick={handleClick}
+            >
+              {(i % 5) + 1 + 5 * offset}
+            </ButtonStyle>
+          );
+        })}
+      <ButtonStyle
+        onClick={() => setPage(page + 1)}
+        disabled={page === maxPage}
+      >
+        &gt;
+      </ButtonStyle>
     </PaginationStyle>
   );
 }
 
 const PaginationStyle = styled.nav`
-  width: 100%;
   height: 5vh;
+  gap: 0.5rem;
   display: flex;
   justify-content: center;
+  button {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
 `;
 
 const ButtonStyle = styled.button`
-  width: 2rem;
-  height: 3rem;
   background-color: transparent;
   border: 0;
 `;

--- a/components/templates/Write.tsx
+++ b/components/templates/Write.tsx
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+import WriteForm from "../organisms/WriteForm";
+
+export default function Write(): JSX.Element {
+  return (
+    <WriteStyle>
+      <WriteForm />
+    </WriteStyle>
+  );
+}
+
+const WriteStyle = styled.section`
+  margin: 2rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;

--- a/types/enum/policy.ts
+++ b/types/enum/policy.ts
@@ -1,0 +1,25 @@
+/**
+ * 게시글 정책
+ * - 제목 : 40자
+ * - 내용 : 2000자
+ * - 작성자 : 10자
+ * - 비밀번호 : 16자
+ */
+export const enum postPolicy {
+  title = 40,
+  content = 2000,
+  writer = 10,
+  password = 16,
+}
+
+/**
+ * 댓글 정책
+ * - 내용 : 500자
+ * - 작성자 : 10자
+ * - 비밀번호 : 16자
+ */
+export const enum commentPolicy {
+  content = 500,
+  writer = 10,
+  password = 16,
+}


### PR DESCRIPTION
# ✨ 추가 기능
- media query를 적용하여 `max-width가 768px 이하`인 경우 모바일 뷰에 맞춰 `Organism` 컴포넌트들의 width를 조절하였습니다.
  - 모든 page의 head에 `<meta content="width=device-width, initial-scale=1" name="viewport" />` 추가

# ♻️ 변경 사항
- post, comment policy를 type으로 지정하여, 정책이 바뀔 시 일괄 적용되도록 하였습니다.